### PR TITLE
namespace type of Context from cairo_t initializer

### DIFF
--- a/src/cairo/context.cr
+++ b/src/cairo/context.cr
@@ -8,7 +8,7 @@ module Cairo
       @cairo = LibCairo.create(target.to_unsafe)
     end
 
-    def initialize(cairo : PCairoT)
+    def initialize(cairo : LibCairo::PCairoT)
       raise ArgumentError.new("'cairo' cannot be null") if cairo.null?
       @cairo = cairo
     end


### PR DESCRIPTION
This seems neccesary to create a high level Context object from a cairo_t I am using in other libraries.