### PR TITLE
Indexable(T) now have unsafe_fetch instead of unsafe_at

### DIFF
--- a/src/cairo/rectangle_list.cr
+++ b/src/cairo/rectangle_list.cr
@@ -28,7 +28,7 @@ module Cairo
     end
 
     @[AlwaysInline]
-    def unsafe_at(index : Int)
+    def unsafe_fetch(index : Int)
       Rectangle.new(@list.value.rectangles[index])
     end
 


### PR DESCRIPTION
https://crystal-lang.org/api/0.31.1/Indexable.html#unsafe_fetch(index:Int)-instance-method

    Error: abstract `def Indexable(T)#unsafe_fetch(index : Int)` must be implemented by Cairo::RectangleList