### PR TITLE
Fix issue while loading image

### DIFF
--- a/src/cairo/context.cr
+++ b/src/cairo/context.cr
@@ -279,7 +279,7 @@ module Cairo
     # - **x** User-space X coordinate for surface origin
     # - **y** User-space Y coordinate for surface origin
     def set_source_surface(surface : Surface, x : Float64, y : Float64)
-      LibCairo.set_source_surface(surface.to_unsafe, x, y)
+      LibCairo.set_source_surface(@cairo, surface.to_unsafe, x, y)
       self
     end
 


### PR DESCRIPTION
While calling `set_source_surface`, Context argument was missing while
calling the respective C binding.

Error:

```
In lib/cairo/src/cairo/context.cr:282:16

 282 | LibCairo.set_source_surface(surface.to_unsafe, x, y)
                ^-----------------
Error: wrong number of arguments for 'Cairo::C::LibCairo#set_source_surface' (given 3, expected 4)
```

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>