### PR TITLE
Fix Context return in pop_group_to_source function

### DIFF
--- a/src/cairo/context.cr
+++ b/src/cairo/context.cr
@@ -197,7 +197,8 @@ module Cairo
     # The `Context#pop_group` function calls `Context#restore`, (balancing a call to `Context#save` by the `Context#push_group` function),
     # so that any changes to the graphics state will not be visible outside the group.
     def pop_group_to_source : Context
-      Context.new(LibCairo.pop_group_to_source(@cairo))
+      LibCairo.pop_group_to_source(@cairo)
+      self
     end
 
     # Sets the compositing operator to be used for all drawing operations.


### PR DESCRIPTION
```
Invalid memory access (signal 11) at address 0x2
[0x56453232c676] *Exception::CallStack::print_backtrace:Nil +118 in /home/aravinda/.cache/crystal/crystal-run-sumne.tmp
[0x56453231b9ea] ~procProc(Int32, Pointer(LibC::SiginfoT), Pointer(Void), Nil) +330 in /home/aravinda/.cache/crystal/crystal-run-sumne.tmp
[0x7f702766b420] ?? +140119674106912 in /lib/x86_64-linux-gnu/libpthread.so.0
[0x7f70278c0fa9] cairo_destroy +9 in /lib/x86_64-linux-gnu/libcairo.so.2
[0x56453239fc5a] *Cairo::Context#finalize:Nil +10 in /home/aravinda/.cache/crystal/crystal-run-sumne.tmp
free(): invalid pointer
Program received and didn't handle signal IOT (6)
```

Above exception was raised when `pop_group_to_source` was called.

Reproducer:

```crystal
require "cairo"

at_exit do
  GC.collect
end

surface = Cairo::SvgSurface.new "test.svg", 400, 300
ctx = Cairo::Context.new surface

ctx.set_source_rgba 1.0, 1.0, 1.0, 1.0
ctx.rectangle 0.0, 0.0, 400.0, 300.0
ctx.fill

ctx.push_group

ctx.set_source_rgba 1.0, 0.0, 0.0, 1.0
ctx.rectangle 0.0, 0.0, 200.0, 100.0
ctx.fill

ctx.operator = Cairo::Operator::In

ctx.set_source_rgba 0.0, 1.0, 0.0, 1.0
ctx.rectangle 100.0, 50.0, 200.0, 100.0
ctx.fill

ctx.pop_group_to_source
ctx.paint

surface.finish
```

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>